### PR TITLE
removing byte order mark from input file (as present in excel generated csv)

### DIFF
--- a/src/se/navitech/adempiere/CAccountSchemaFile.java
+++ b/src/se/navitech/adempiere/CAccountSchemaFile.java
@@ -300,7 +300,9 @@ public class CAccountSchemaFile {
      * @param   line    The line to be checked.
      */
     private boolean checkFirstLine(String line) throws Exception {
-        // Split the line
+    	// remove BOM if present
+    	line = removeBOM(line);
+         // Split the line
         Pattern pattern = Pattern.compile("\\]{0,1},\\[{0,1}", Pattern.CASE_INSENSITIVE);
         String[] colNames = pattern.split(line);
         if (colNames.length>=MIN_NCOLS) {
@@ -343,6 +345,19 @@ public class CAccountSchemaFile {
         }
         
         return(colNames.length>=MIN_NCOLS);
+    }
+    
+    /**
+     * Removes Byte order Mark if present (as added by Excel)
+     * @param string
+     */
+    
+    private static String removeBOM(String string) {
+    	final String UTF8_BOM = "\uFEFF";
+        if (string.startsWith(UTF8_BOM)) {
+            string = string.substring(1);
+        }
+        return string;
     }
     
 }

--- a/src/se/navitech/adempiere/gui/CSchemaFileMainFrame.java
+++ b/src/se/navitech/adempiere/gui/CSchemaFileMainFrame.java
@@ -237,7 +237,8 @@ public class CSchemaFileMainFrame extends JInternalFrame implements KeyListener,
         m_defAcctTableModel = new CDefAcctTableModel(m_schemaFile.getSchema());
         initComponents();
         // Insert empty element in default account combobox
-        ((DefaultComboBoxModel)defaultAcctCombo.getModel()).insertElementAt(new CDefaultAccount("", ""), 0);
+        if(defaultAcctCombo.getModel() instanceof DefaultComboBoxModel<?>)
+        	((DefaultComboBoxModel<CDefaultAccount>)defaultAcctCombo.getModel()).insertElementAt(new CDefaultAccount("", ""), 0);
         defaultAcctCombo.setSelectedIndex(0);
         
         setTitle(schemaFile!=null ? schemaFile.getAbsolutePath() : "New schema");
@@ -565,7 +566,7 @@ public class CSchemaFileMainFrame extends JInternalFrame implements KeyListener,
         summaryAcctLabel = new JLabel();
         summaryAcctCheck = new JCheckBox();
         defaultAccountLabel = new JLabel();
-        defaultAcctCombo = new JComboBox(m_defaultAccountVector);
+        defaultAcctCombo = new JComboBox<CDefaultAccount>(m_defaultAccountVector);
         acctParentLabel = new JLabel();
         balanceSheetLabel = new JLabel();
         balanceSheetText = new JTextField();
@@ -597,9 +598,9 @@ public class CSchemaFileMainFrame extends JInternalFrame implements KeyListener,
         acctDescLabel = new JLabel();
         acctDescText = new JTextField();
         acctTypeLabel = new JLabel();
-        acctTypeCombo = new JComboBox(CAccountType.m_accountTypes);
+        acctTypeCombo = new JComboBox<String>(CAccountType.m_accountTypes);
         acctSignLabel = new JLabel();
-        acctSignCombo = new JComboBox();
+        acctSignCombo = new JComboBox<>();
         accountListPanel = new JPanel();
         accountListBgPanel = new JPanel();
         accountListScrollPane = new JScrollPane();
@@ -888,7 +889,7 @@ public class CSchemaFileMainFrame extends JInternalFrame implements KeyListener,
 
         acctSignLabel.setText("Account sign");
 
-        acctSignCombo.setModel(new DefaultComboBoxModel(new String[] { "", "Natural", "Debit", "Credit" }));
+        acctSignCombo.setModel(new DefaultComboBoxModel<String>(new String[] { "", "Natural", "Debit", "Credit" }));
 
         org.jdesktop.layout.GroupLayout jPanel2Layout = new org.jdesktop.layout.GroupLayout(jPanel2);
         jPanel2.setLayout(jPanel2Layout);
@@ -1278,9 +1279,9 @@ public class CSchemaFileMainFrame extends JInternalFrame implements KeyListener,
     private JTextField acctNameText;
     private JLabel acctParentLabel;
     private JTextField acctParentText;
-    private JComboBox acctSignCombo;
+    private JComboBox<String> acctSignCombo;
     private JLabel acctSignLabel;
-    private JComboBox acctTypeCombo;
+    private JComboBox<String> acctTypeCombo;
     private JLabel acctTypeLabel;
     private JLabel acctValueLabel;
     private JTextField acctValueText;
@@ -1299,7 +1300,7 @@ public class CSchemaFileMainFrame extends JInternalFrame implements KeyListener,
     private JScrollPane defAcctScrollPane;
     private JTable defAcctTable;
     private JLabel defaultAccountLabel;
-    private JComboBox defaultAcctCombo;
+    private JComboBox<CDefaultAccount> defaultAcctCombo;
     private JPanel detailsPanel;
     private JCheckBox docCtlCheck;
     private JLabel docCtlLabel;


### PR DESCRIPTION
The editor gave me an error message when I tried to import an excel generated account file.
Here is a fix. It removes the byte order mark from the input file (if present).

The pull request also includes a few modifications that where made to clear eclipse warnings regarding the usage of generic types. I hope you won't mind that I kept both rather small modifications together in a single pull request.